### PR TITLE
Accept bytes instead of lists of bools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Binary visualization using IPython widgets. This is a Jupyter/IPython notebook e
 
 Canvas + IPython widgets are so slick.
 
-![bitjet](https://cloud.githubusercontent.com/assets/836375/6262945/31bfd5c8-b7c3-11e4-9f87-55a80f28ca6c.gif)
+![bitjet](https://cloud.githubusercontent.com/assets/836375/6284459/07c69e7c-b8a5-11e4-9fbd-98b1d2b55e3e.gif)
 
 Currently, this has to be installed using setup.py.
 

--- a/bitjet/bitjet.js
+++ b/bitjet/bitjet.js
@@ -12,7 +12,8 @@ define(function(require) {
                    height: 800,
                    border: '1px solid lightgray',
                    "-webkit-box-shadow": "0 0 12px 1px rgba(87,87,87,0.2)",
-                   "box-shadow": "0 0 12px 1px rgba(87,87,87,0.2)"
+                   "box-shadow": "0 0 12px 1px rgba(87,87,87,0.2)",
+                   background: "rgba(87,87,87,0.2)"
                }).appendTo(this.$el);
 
 
@@ -28,28 +29,44 @@ define(function(require) {
           var canvas = this.$frame[0];
           var context = canvas.getContext("2d");
 
+          // Color the background gray
+          context.fillStyle = "rgb(87,87,87,0.2)";
           context.clearRect(0, 0, canvas.width, canvas.height );
 
-          var data = this.model.get("data");
-          // data will come in as a list traitlet
+          // We expect JSON with base64 encoded data in the b64data field
+          var msg = this.model.get("data");
+          var data = atob(msg['b64data']);
+
           var bitwidth = this.model.get("bitwidth");
 
           var width = this.model.get("blockwidth");
           var height = this.model.get("blockheight");
 
-          data.forEach(function(el, idx) {
-            // Within each byte, fill for each bit
-            for (i=0; i<8; i++){
-              bit = el >> i
-              var x = ((idx*8+i) % bitwidth)*width;
-              var y = (Math.floor((idx*8+i)/bitwidth))*height;
+          // Paint the canvas with our bit view
+          for(var idx=0; idx < data.length; idx++) {
+            // The decoded data is a string in JavaScript land, we'll strip uint8s off
+            var el = data.charCodeAt(idx);
+            var charsize = 8; 
+
+            for (i=0; i<charsize; i++){
+              //Mask off that first bit
+              var bit = (el >> i) & 0x1;
+              
+              // Where does this bit fit in it?
+              var x = ((idx*charsize+i) % bitwidth)*width;
+              var y = (Math.floor((idx*charsize+i)/bitwidth))*height;
+
               if(bit) { //on
+                context.fillStyle = "rgb(255,255,255)";
+                context.fillRect(x,y,width,height);
+              } else {
+                context.fillStyle = "rgb(0,0,0)";
                 context.fillRect(x,y,width,height);
               }
 
             }
               
-          });
+          }
 
        },
    });

--- a/bitjet/bitjet.js
+++ b/bitjet/bitjet.js
@@ -28,7 +28,7 @@ define(function(require) {
           var canvas = this.$frame[0];
           var context = canvas.getContext("2d");
 
-          context.clearRect ( 0 , 0 , canvas.width, canvas.height );
+          context.clearRect(0, 0, canvas.width, canvas.height );
 
           var data = this.model.get("data");
           // data will come in as a list traitlet
@@ -37,16 +37,18 @@ define(function(require) {
           var width = this.model.get("blockwidth");
           var height = this.model.get("blockheight");
 
-          var that = this;
           data.forEach(function(el, idx) {
-            if(el) {
-
-              var x = (idx % bitwidth)*width;
-              var y = (Math.floor(idx/bitwidth))*height;
-
-              context.fillRect(x,y,width,height);
+            // Within each byte, fill for each bit
+            for (i=0; i<8; i++){
+              bit = el >> i
+              var x = ((idx*8+i) % bitwidth)*width;
+              var y = (Math.floor((idx*8+i)/bitwidth))*height;
+              if(bit) { //on
+                context.fillRect(x,y,width,height);
+              }
 
             }
+              
           });
 
        },

--- a/bitjet/bitjet.py
+++ b/bitjet/bitjet.py
@@ -5,6 +5,12 @@ from IPython.utils.traitlets import Int, Unicode, List, Instance, Bytes
 
 import base64
 
+try:
+    from numpy import ndarray
+except:
+    ndarray = None
+
+
 def b64encode_json(a):
     return {'b64data': base64.b64encode(a)}
 
@@ -14,8 +20,10 @@ class BitWidget(DOMWidget):
 
     bitwidth = Int(2, sync=True)
 
-    data = Bytes(sync=True, to_json=b64encode_json)
-    #data = List(Int(), sync=True) # | Bytes(sync=True) # | Instance(bytearray, sync=True)
+    data = (
+            Bytes(sync=True, to_json=b64encode_json) |
+            Instance(ndarray, sync=True, to_json=b64encode_json)
+    )
 
     blockwidth = Int(4, sync=True)
     blockheight = Int(4, sync=True)

--- a/bitjet/bitjet.py
+++ b/bitjet/bitjet.py
@@ -1,24 +1,15 @@
 import mmap
 
 from IPython.html.widgets import DOMWidget
-from IPython.utils.traitlets import Int, Unicode, List
+from IPython.utils.traitlets import Int, Unicode, List, Instance, Bytes
 
 class BitWidget(DOMWidget):
     _view_module = Unicode('nbextensions/bitjet/bitjet', sync=True)
     _view_name = Unicode('BitView', sync=True)
 
-
     bitwidth = Int(2, sync=True)
-    data = List([True, False, True, False], sync=True)
+
+    data = List(Int(), sync=True) # | Bytes(sync=True) # | Instance(bytearray, sync=True)
+
     blockwidth = Int(4, sync=True)
     blockheight = Int(4, sync=True)
-
-
-#class FileView(BitWidget):
-#    
-#    def __init__(self, filename):
-#        # TODO: Figure out proper way to extend Widgets
-#        self.fh = open(filename,"rb")
-#        self.m = mmap.mmap(self.fh.fileno(), 0, access=mmap.ACCESS_READ)
-#        ba = bytearray(m)
-#        np.array(ba)

--- a/bitjet/bitjet.py
+++ b/bitjet/bitjet.py
@@ -3,13 +3,19 @@ import mmap
 from IPython.html.widgets import DOMWidget
 from IPython.utils.traitlets import Int, Unicode, List, Instance, Bytes
 
+import base64
+
+def b64encode_json(a):
+    return {'b64data': base64.b64encode(a)}
+
 class BitWidget(DOMWidget):
     _view_module = Unicode('nbextensions/bitjet/bitjet', sync=True)
     _view_name = Unicode('BitView', sync=True)
 
     bitwidth = Int(2, sync=True)
 
-    data = List(Int(), sync=True) # | Bytes(sync=True) # | Instance(bytearray, sync=True)
+    data = Bytes(sync=True, to_json=b64encode_json)
+    #data = List(Int(), sync=True) # | Bytes(sync=True) # | Instance(bytearray, sync=True)
 
     blockwidth = Int(4, sync=True)
     blockheight = Int(4, sync=True)

--- a/bitvis.ipynb
+++ b/bitvis.ipynb
@@ -34,14 +34,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 19,
    "metadata": {
     "collapsed": false,
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "bw.data = os.urandom(32) + b'nowflyingbitjet'"
+    "bw.data = os.urandom(12) + b'nowflyingbitjet'"
    ]
   },
   {
@@ -90,14 +90,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 20,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "bitjet.BitWidget(data=np.array([1,2,3,4,5,6,7,7,7,7,7], dtype=np.uint8), bitwidth=8)"
+    "bitjet.BitWidget(data=np.array([1,2,3,4,5,6], dtype=np.uint8), bitwidth=8)"
    ]
   },
   {

--- a/bitvis.ipynb
+++ b/bitvis.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {
     "collapsed": false
@@ -25,7 +34,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -34,20 +43,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [],
    "source": [
-    "data = ([True, False, True, True, True, False, False, False, True, False, False, True, True, False]*24 +\n",
-    "        [True, False]*20 + [True]*10 + [True, False, True]*12)*24\n",
+    "data = [0xff, 0xfe, 0x03, 0x7d]*200\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "data = os.urandom(100)\n",
+    "\n",
     "bw.data = data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 4,
    "metadata": {
     "collapsed": true
    },
@@ -58,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -79,6 +93,148 @@
    "source": [
     "bw"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "bytearray(b'\\x91\\xd5\\x9bw\\x88!\\xb9\\x8c\\rK\\xb1ce\\xa8\\xda\\xb21\\xd1\\nQV\"(\\xed\\xeb\\xa3\\xe0\\x88\\x15\\x80\\xe9\\xbf\\xfd\\xd9\\xb5\\xb7>\\t\\xf9\\xa2\\xf3r\\x94G1\\xc6.\\xa2\\xb2h^\\xce\\x11\\xbb\\xe1jp\\xb04c\\x8a\\xc3\\xc0\\xc9c\\xf8\\xe9qE\\x18\\xd0\\xe5\\xb9\\x82\\'\\xd1O1\\'\\x100O3)\\xc8\\xbc]\\xbfh\\xf0\\xbe\\x12\\x9d \\xa6\\xf3\\x9f\\x83\\x03\\xf5')"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "bytearray(os.urandom(100))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.utils.traitlets import Int, Unicode, List, Union, Instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "undata = Union([List(), Instance(np.ndarray)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "data = List()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<IPython.utils.traitlets.List at 0x104ccb2b0>"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<IPython.utils.traitlets.Union at 0x104ccb978>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "undata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "data = np.array([True, False])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ True, False], dtype=bool)"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/bitvis.ipynb
+++ b/bitvis.ipynb
@@ -2,15 +2,6 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
    "execution_count": 1,
    "metadata": {
     "collapsed": false
@@ -25,6 +16,7 @@
     }
    ],
    "source": [
+    "import os\n",
     "import bitjet\n",
     "from IPython.html.widgets import IntSlider\n",
     "from IPython.utils.traitlets import link"
@@ -43,20 +35,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false,
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "data = [0xff, 0xfe, 0x03, 0x7d]*200\n",
-    "\n",
-    "import os\n",
-    "\n",
-    "data = os.urandom(100)\n",
-    "\n",
-    "bw.data = data"
+    "bw.data = b'0123456789abcdefghijklm' + os.urandom(13) + b'nopqrstuvwxyz'"
    ]
   },
   {
@@ -67,7 +53,7 @@
    },
    "outputs": [],
    "source": [
-    "bw.blockwidth = bw.blockheight = 2"
+    "bw.blockwidth = bw.blockheight = 4"
    ]
   },
   {
@@ -92,139 +78,6 @@
    "outputs": [],
    "source": [
     "bw"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "bytearray(b'\\x91\\xd5\\x9bw\\x88!\\xb9\\x8c\\rK\\xb1ce\\xa8\\xda\\xb21\\xd1\\nQV\"(\\xed\\xeb\\xa3\\xe0\\x88\\x15\\x80\\xe9\\xbf\\xfd\\xd9\\xb5\\xb7>\\t\\xf9\\xa2\\xf3r\\x94G1\\xc6.\\xa2\\xb2h^\\xce\\x11\\xbb\\xe1jp\\xb04c\\x8a\\xc3\\xc0\\xc9c\\xf8\\xe9qE\\x18\\xd0\\xe5\\xb9\\x82\\'\\xd1O1\\'\\x100O3)\\xc8\\xbc]\\xbfh\\xf0\\xbe\\x12\\x9d \\xa6\\xf3\\x9f\\x83\\x03\\xf5')"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import os\n",
-    "bytearray(os.urandom(100))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "from IPython.utils.traitlets import Int, Unicode, List, Union, Instance"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "undata = Union([List(), Instance(np.ndarray)])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "data = List()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<IPython.utils.traitlets.List at 0x104ccb2b0>"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<IPython.utils.traitlets.Union at 0x104ccb978>"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "undata"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "data = np.array([True, False])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([ True, False], dtype=bool)"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "data"
    ]
   },
   {

--- a/bitvis.ipynb
+++ b/bitvis.ipynb
@@ -9,21 +9,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      ":0: FutureWarning: IPython widgets are experimental and may change in the future.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import os\n",
+    "import os, string\n",
     "import bitjet\n",
     "from IPython.html.widgets import IntSlider\n",
     "from IPython.utils.traitlets import link"
@@ -42,22 +34,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false,
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "from numpy import ndarray\n",
-    "import numpy as np\n",
-    "\n",
-    "bw.data = np.array([1,2,3,4,5], dtype=np.uint8)"
+    "bw.data = os.urandom(32) + b'nowflyingbitjet'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 11,
    "metadata": {
     "collapsed": true
    },
@@ -68,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -81,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 13,
    "metadata": {
     "collapsed": true
    },
@@ -101,14 +90,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "bitjet.BitWidget(data=np.array([1,2,3,4,5], dtype=np.uint8), bitwidth=8)"
+    "bitjet.BitWidget(data=np.array([1,2,3,4,5,6,7,7,7,7,7], dtype=np.uint8), bitwidth=8)"
    ]
   },
   {

--- a/bitvis.ipynb
+++ b/bitvis.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Bit Jet"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -35,14 +42,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false,
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "bw.data = b'0123456789abcdefghijklm' + os.urandom(13) + b'nopqrstuvwxyz'"
+    "from numpy import ndarray\n",
+    "import numpy as np\n",
+    "\n",
+    "bw.data = np.array([1,2,3,4,5], dtype=np.uint8)"
    ]
   },
   {
@@ -78,6 +88,27 @@
    "outputs": [],
    "source": [
     "bw"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "## Compatible with numpy!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "bitjet.BitWidget(data=np.array([1,2,3,4,5], dtype=np.uint8), bitwidth=8)"
    ]
   },
   {


### PR DESCRIPTION
This swaps bitjet over to accepting Integers instead of Bools.

Soon I'd like to make this work with `bytearray`s and `numpy.ndarray`s.
