### PR TITLE
DRY up the JavaScript views

### DIFF
--- a/bitjet/bitjet.js
+++ b/bitjet/bitjet.js
@@ -14,7 +14,7 @@ define(function(require) {
 
    var BinaryView = widget.DOMWidgetView.extend({
        render: function() {
-           
+
            // Create the viewing frame.
            this.$frame = $('<canvas/>')
                .css({
@@ -29,30 +29,28 @@ define(function(require) {
            this.model.on('change:datawidth', this._redraw, this);
            this.model.on('change:blockwidth', this._redraw, this);
            this.model.on('change:blockheight', this._redraw, this);
-           
+
            this.model.on('change:width', this._redraw, this);
            this.model.on('change:height', this._redraw, this);
-           
+
            this._redraw();
        }
-   });
 
-   var BitView = BinaryView.extend({
        _redraw: function() {
           var data = this.model.get('_data');
-          
+
           // Set the width/height of the canvas and the canvas's drawing space
           var width = this.model.get('width');
           var height = this.model.get('height');
-            
+
           // Width/height of the Canvas on the DOM
           this.$frame.width(width);
           this.$frame.height(height);
-           
+
           // Width/height of the canvas area
           this.$frame[0].width = width;
           this.$frame[0].height = height;
-          
+
           // Grab the canvas context
           var canvas = this.$frame[0];
           var context = canvas.getContext("2d");
@@ -61,24 +59,37 @@ define(function(require) {
           context.fillStyle = "rgb(87,87,87,0.2)";
           context.clearRect(0, 0, canvas.width, canvas.height );
 
-          var bitwidth = this.model.get("datawidth");
-
+          var datawidth = this.model.get("datawidth");
           var width = this.model.get("blockwidth");
           var height = this.model.get("blockheight");
+
+          self._paintData(context, data, datawidth,
+                          width, height,
+                          blockwidth, blockheight)
+
+       },
+
+   });
+
+   var BitView = BinaryView.extend({
+
+     _paintData: function(canvasCtx, data, datawidth,
+                          width, height,
+                          blockwidth, blockheight) {
 
           // Paint the canvas with our bit view
           for(var idx=0; idx < data.length; idx++) {
             // The decoded data is a string in JavaScript land, we'll strip uint8s off
             var el = data.charCodeAt(idx);
-            var charsize = 8; 
+            var charsize = 8;
 
             for (i=0; i<charsize; i++){
               //Mask off that first bit
               var bit = (el >> 7-i) & 0x1; // shift down from the leftmost bit
-              
+
               // Where does this bit fit in it?
-              var x = ((idx*charsize+i) % bitwidth)*width;
-              var y = (Math.floor((idx*charsize+i)/bitwidth))*height;
+              var x = ((idx*charsize+i) % datawidth)*width;
+              var y = (Math.floor((idx*charsize+i)/datawidth))*height;
 
               if(bit) { //on
                 context.fillStyle = "rgb(255,255,255)";
@@ -89,7 +100,7 @@ define(function(require) {
               }
 
             }
-              
+
           }
 
        },
@@ -97,49 +108,24 @@ define(function(require) {
 
    var ByteView = BinaryView.extend({
 
-       _redraw: function() {
-          var data = this.model.get('_data');
-          
-          // Set the width/height of the canvas and the canvas's drawing space
-          var width = this.model.get('width');
-          var height = this.model.get('height');
-            
-          // Width/height of the Canvas on the DOM
-          this.$frame.width(width);
-          this.$frame.height(height);
-           
-          // Width/height of the canvas area
-          this.$frame[0].width = width;
-          this.$frame[0].height = height;
-          
-          // Grab the canvas context
-          var canvas = this.$frame[0];
-          var context = canvas.getContext("2d");
+       _paintData: function(canvasCtx, data, datawidth,
+                            width, height,
+                            blockwidth, blockheight) {
 
-          // Color the background gray
-          context.fillStyle = "rgb(87,87,87,0.2)";
-          context.clearRect(0, 0, canvas.width, canvas.height );
+         // Paint the canvas with our byte view
+         for(var idx=0; idx < data.length; idx++) {
+           // The decoded data is a string in JavaScript land, we'll strip uint8s off
+           var el = data.charCodeAt(idx);
 
-          var bytewidth = this.model.get("datawidth");
+           // Where does this byte get painted?
+           var x = (idx % datawidth)*width;
+           var y = (Math.floor(idx/datawidth))*height;
 
-          var width = this.model.get("blockwidth");
-          var height = this.model.get("blockheight");
+           canvasCtx.fillStyle = "rgb(" +  [el,el,el].join() + ")"
+           canvasCtx.fillRect(x,y,width,height);
 
-          // Paint the canvas with our byte view
-          for(var idx=0; idx < data.length; idx++) {
-            // The decoded data is a string in JavaScript land, we'll strip uint8s off
-            var el = data.charCodeAt(idx);
-
-            // Where does this byte get painted?
-            var x = (idx % bytewidth)*width;
-            var y = (Math.floor(idx/bytewidth))*height;
-
-            context.fillStyle = "rgb(" +  [el,el,el].join() + ")"
-            context.fillRect(x,y,width,height);
-              
-          }
-
-       },
+         }
+       }
    });
 
    return {

--- a/bitjet/bitjet.js
+++ b/bitjet/bitjet.js
@@ -34,20 +34,19 @@ define(function(require) {
            this.model.on('change:height', this._redraw, this);
 
            this._redraw();
-       }
+       },
 
        _redraw: function() {
           var data = this.model.get('_data');
 
-          // Set the width/height of the canvas and the canvas's drawing space
           var width = this.model.get('width');
           var height = this.model.get('height');
 
-          // Width/height of the Canvas on the DOM
+          // Set width/height of the Canvas on the DOM
           this.$frame.width(width);
           this.$frame.height(height);
 
-          // Width/height of the canvas area
+          // Set width/height of the canvas drawing area
           this.$frame[0].width = width;
           this.$frame[0].height = height;
 
@@ -60,21 +59,19 @@ define(function(require) {
           context.clearRect(0, 0, canvas.width, canvas.height );
 
           var datawidth = this.model.get("datawidth");
-          var width = this.model.get("blockwidth");
-          var height = this.model.get("blockheight");
+          var blockwidth = this.model.get("blockwidth");
+          var blockheight = this.model.get("blockheight");
 
-          self._paintData(context, data, datawidth,
-                          width, height,
+          this._paintData(context, data, datawidth,
                           blockwidth, blockheight)
 
-       },
+       }
 
    });
 
    var BitView = BinaryView.extend({
 
      _paintData: function(canvasCtx, data, datawidth,
-                          width, height,
                           blockwidth, blockheight) {
 
           // Paint the canvas with our bit view
@@ -88,28 +85,27 @@ define(function(require) {
               var bit = (el >> 7-i) & 0x1; // shift down from the leftmost bit
 
               // Where does this bit fit in it?
-              var x = ((idx*charsize+i) % datawidth)*width;
-              var y = (Math.floor((idx*charsize+i)/datawidth))*height;
+              var x = ((idx*charsize+i) % datawidth)*blockwidth;
+              var y = (Math.floor((idx*charsize+i)/datawidth))*blockheight;
 
               if(bit) { //on
-                context.fillStyle = "rgb(255,255,255)";
-                context.fillRect(x,y,width,height);
+                canvasCtx.fillStyle = "rgb(255,255,255)";
+                canvasCtx.fillRect(x,y,blockwidth,blockheight);
               } else {
-                context.fillStyle = "rgb(0,0,0)";
-                context.fillRect(x,y,width,height);
+                canvasCtx.fillStyle = "rgb(0,0,0)";
+                canvasCtx.fillRect(x,y,blockwidth,blockheight);
               }
 
             }
 
           }
 
-       },
+       }
    });
 
    var ByteView = BinaryView.extend({
 
        _paintData: function(canvasCtx, data, datawidth,
-                            width, height,
                             blockwidth, blockheight) {
 
          // Paint the canvas with our byte view
@@ -118,11 +114,11 @@ define(function(require) {
            var el = data.charCodeAt(idx);
 
            // Where does this byte get painted?
-           var x = (idx % datawidth)*width;
-           var y = (Math.floor(idx/datawidth))*height;
+           var x = (idx % datawidth)*blockwidth;
+           var y = (Math.floor(idx/datawidth))*blockheight;
 
            canvasCtx.fillStyle = "rgb(" +  [el,el,el].join() + ")"
-           canvasCtx.fillRect(x,y,width,height);
+           canvasCtx.fillRect(x,y,blockwidth,blockheight);
 
          }
        }

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except:
 
 setup(
     name='bitjet',
-    version='0.2.1',
+    version='0.2.2',
     description='Binary visualization using IPython widgets',
     author='Kyle Kelley',
     author_email='rgbkrk@gmail.com',


### PR DESCRIPTION
This was getting a bit hairier and prone to bugs the more there was repeated code between the ByteView and BitView.

If I ever accept @ellisonbg's suggestion to make the "character length" more configurable (n-bits per block instead of 8 bits and 1-bit), I'll probably have to revisit this.
