### PR TITLE
Upgrade ipywidgets

### DIFF
--- a/bitjet/bitjet.js
+++ b/bitjet/bitjet.js
@@ -24,9 +24,6 @@ define(function(require) {
            this.model.on('change:blockwidth', this._redraw, this);
            this.model.on('change:blockheight', this._redraw, this);
 
-           this.model.on('change:width', this._redraw, this);
-           this.model.on('change:height', this._redraw, this);
-
            this.model.on('change:bits_per_block', this._redraw, this);
 
            this._redraw();
@@ -34,9 +31,15 @@ define(function(require) {
 
        _redraw: function() {
           var data = this.model.get('data');
+          var datawidth = this.model.get("datawidth");
+          var blockwidth = this.model.get("blockwidth");
+          var blockheight = this.model.get("blockheight");
+          var bitsPerBlock = this.model.get("bits_per_block");
 
-          var width = this.model.get('width');
-          var height = this.model.get('height');
+          var datacol = Math.ceil(data.length/datawidth);
+
+          var width = datawidth*bitsPerBlock*blockwidth;
+          var height = datacol*bitsPerBlock*blockheight*8;
 
           // Set width/height of the Canvas on the DOM
           this.$frame.width(width);
@@ -54,11 +57,6 @@ define(function(require) {
           context.fillStyle = "rgb(87,87,87,0.2)";
           context.clearRect(0, 0, canvas.width, canvas.height );
 
-          var datawidth = this.model.get("datawidth");
-          var blockwidth = this.model.get("blockwidth");
-          var blockheight = this.model.get("blockheight");
-
-          var bitsPerBlock = this.model.get("bits_per_block");
           if (bitsPerBlock === 1) {
             paintBits(context, data, datawidth, blockwidth, blockheight);
           } else if (bitsPerBlock === 8) {
@@ -81,6 +79,7 @@ define(function(require) {
       // The decoded data is a string in JavaScript land, we'll strip uint8s off
       var el = data.charCodeAt(idx);
       var charsize = 8;
+      console.log(el);
 
       for (i=0; i<charsize; i++){
         //Mask off that first bit

--- a/bitjet/bitjet.js
+++ b/bitjet/bitjet.js
@@ -7,8 +7,8 @@ define(function(require) {
      },
 
      _decode: function() {
-       var msg = this.get("data");
-       this.set('_data', atob(msg['b64data']));
+       var data = this.get("data");
+       this.set('_data', data);
      }
    });
 

--- a/bitjet/bitjet.js
+++ b/bitjet/bitjet.js
@@ -1,10 +1,7 @@
 define(function(require) {
    var widget = require("widgets/js/widget");
 
-   var BinaryModel = widget.WidgetModel.extend({
-     initialize: function() {
-     },
-   });
+   var BinaryModel = widget.WidgetModel.extend({});
 
    var BinaryView = widget.DOMWidgetView.extend({
        render: function() {

--- a/bitjet/bitjet.js
+++ b/bitjet/bitjet.js
@@ -33,8 +33,11 @@ define(function(require) {
           var blockwidth = this.model.get("blockwidth");
           var blockheight = this.model.get("blockheight");
           var bitsPerBlock = this.model.get("bits_per_block");
+          var datacol = 0;
+          if (data !== null) {
+            datacol = Math.ceil(data.byteLength/datawidth);
+          }
 
-          var datacol = Math.ceil(data.length/datawidth);
 
           var width = datawidth*bitsPerBlock*blockwidth;
           var height = datacol*bitsPerBlock*blockheight*8;
@@ -54,7 +57,11 @@ define(function(require) {
           // Color the background gray
           context.fillStyle = "rgb(87,87,87,0.2)";
           context.clearRect(0, 0, canvas.width, canvas.height );
-
+          
+          if (data === null) {
+            // no data
+            return;
+          }
           if (bitsPerBlock === 1) {
             paintBits(context, data, datawidth, blockwidth, blockheight);
           } else if (bitsPerBlock === 8) {
@@ -72,15 +79,10 @@ define(function(require) {
                       blockwidth, blockheight) {
 
     // Paint the canvas with our bit view
-    for(var idx=0; idx < data.length; idx++) {
-      // The decoded data is a string in JavaScript land, we'll strip uint8s off
-      var el = data.charCodeAt(idx);
+    for(var idx=0; idx < data.byteLength; idx++) {
+      // The decoded data is a DataView in JavaScript land, we'll strip uint8s off
+      var el = data.getUint8(idx);
       var charsize = 8;
-      // TODO: For some reason, values >= 128 are all coming out at 65533 (2^16 - 3)
-      //       which when masked, is 253. Not sure if traitlets is somehow masking it
-      //       or what...
-      // console.log(el); // If the actual data[idx] >= 128, el == 65533
-      // console.log(el & 0xff); // which would then make the effective value 253
 
       for (i=0; i<charsize; i++){
         //Mask off that first bit
@@ -108,9 +110,9 @@ define(function(require) {
                        blockwidth, blockheight) {
 
          // Paint the canvas with our byte view
-         for(var idx=0; idx < data.length; idx++) {
-           // The decoded data is a string in JavaScript land, we'll strip uint8s off
-           var el = data.charCodeAt(idx);
+         for(var idx=0; idx < data.byteLength; idx++) {
+           // The decoded data is a DataView in JavaScript land, we'll strip uint8s off
+           var el = data.getUint8(idx);
 
            // Where does this byte get painted?
            var x = (idx % datawidth)*blockwidth;

--- a/bitjet/bitjet.js
+++ b/bitjet/bitjet.js
@@ -90,10 +90,10 @@ define(function(require) {
         var x = ((idx*charsize+i) % datawidth)*blockwidth;
         var y = (Math.floor((idx*charsize+i)/datawidth))*blockheight;
 
-        if(bit) { //on
+        if(bit) { // on
           canvasCtx.fillStyle = "rgb(255,255,255)";
           canvasCtx.fillRect(x,y,blockwidth,blockheight);
-        } else {
+        } else { // off
           canvasCtx.fillStyle = "rgb(0,0,0)";
           canvasCtx.fillRect(x,y,blockwidth,blockheight);
         }

--- a/bitjet/bitjet.js
+++ b/bitjet/bitjet.js
@@ -79,8 +79,8 @@ define(function(require) {
       // TODO: For some reason, values >= 128 are all coming out at 65533 (2^16 - 3)
       //       which when masked, is 253. Not sure if traitlets is somehow masking it
       //       or what...
-      // console.log(el);
-      // console.log(el & 0xff);
+      // console.log(el); // If the actual data[idx] >= 128, el == 65533
+      // console.log(el & 0xff); // which would then make the effective value 253
 
       for (i=0; i<charsize; i++){
         //Mask off that first bit

--- a/bitjet/bitjet.js
+++ b/bitjet/bitjet.js
@@ -72,14 +72,17 @@ define(function(require) {
 
    function paintBits(canvasCtx, data, datawidth,
                       blockwidth, blockheight) {
-                      window.y = data;
 
     // Paint the canvas with our bit view
     for(var idx=0; idx < data.length; idx++) {
       // The decoded data is a string in JavaScript land, we'll strip uint8s off
       var el = data.charCodeAt(idx);
       var charsize = 8;
-      console.log(el);
+      // TODO: For some reason, values >= 128 are all coming out at 65533 (2^16 - 3)
+      //       which when masked, is 253. Not sure if traitlets is somehow masking it
+      //       or what...
+      // console.log(el);
+      // console.log(el & 0xff);
 
       for (i=0; i<charsize; i++){
         //Mask off that first bit

--- a/bitjet/bitjet.js
+++ b/bitjet/bitjet.js
@@ -21,6 +21,7 @@ define(function(require) {
            this.model.on('change:blockwidth', this._redraw, this);
            this.model.on('change:blockheight', this._redraw, this);
 
+           // Used for 1 bit per block (binary view) or 8 bit per block (hex view)
            this.model.on('change:bits_per_block', this._redraw, this);
 
            this._redraw();

--- a/bitjet/bitjet.js
+++ b/bitjet/bitjet.js
@@ -3,13 +3,7 @@ define(function(require) {
 
    var BinaryModel = widget.WidgetModel.extend({
      initialize: function() {
-       this.on('change:data', this._decode, this);
      },
-
-     _decode: function() {
-       var data = this.get("data");
-       this.set('_data', data);
-     }
    });
 
    var BinaryView = widget.DOMWidgetView.extend({
@@ -25,7 +19,7 @@ define(function(require) {
                    background: "rgba(87,87,87,0.2)"
                }).appendTo(this.$el);
 
-           this.model.on('change:_data', this._redraw, this);
+           this.model.on('change:data', this._redraw, this);
            this.model.on('change:datawidth', this._redraw, this);
            this.model.on('change:blockwidth', this._redraw, this);
            this.model.on('change:blockheight', this._redraw, this);
@@ -39,7 +33,7 @@ define(function(require) {
        },
 
        _redraw: function() {
-          var data = this.model.get('_data');
+          var data = this.model.get('data');
 
           var width = this.model.get('width');
           var height = this.model.get('height');
@@ -80,6 +74,7 @@ define(function(require) {
 
    function paintBits(canvasCtx, data, datawidth,
                       blockwidth, blockheight) {
+                      window.y = data;
 
     // Paint the canvas with our bit view
     for(var idx=0; idx < data.length; idx++) {

--- a/bitjet/bitjet.py
+++ b/bitjet/bitjet.py
@@ -11,7 +11,7 @@ class BinaryView(DOMWidget):
     _model_module = Unicode('nbextensions/bitjet/bitjet', sync=True)
     _model_name = Unicode('BinaryModel', sync=True)
 
-    datawidth = Int(2, sync=True)
+    datawidth = Int(8, sync=True)
 
     data = Bytes(sync=True)
 

--- a/bitjet/bitjet.py
+++ b/bitjet/bitjet.py
@@ -5,6 +5,13 @@ from traitlets import Int, Unicode, List, Instance, Bytes, Enum
 
 import base64
 
+def bytes_to_json(buf, widget):
+    """Wrap bytes objects in memoryviews to trigger binary messages."""
+    if not buf:
+        # temporary workaround since open doesn't support binary serialization
+        return None
+    return memoryview(buf)
+
 class BinaryView(DOMWidget):
     _view_module = Unicode('nbextensions/bitjet/bitjet', sync=True)
     _view_name = Unicode('BinaryView', sync=True)
@@ -13,12 +20,22 @@ class BinaryView(DOMWidget):
 
     datawidth = Int(8, sync=True)
 
-    data = Bytes(sync=True)
+    data = Bytes(sync=True, to_json=bytes_to_json)
 
     blockwidth = Int(4, sync=True)
     blockheight = Int(4, sync=True)
 
     bits_per_block = Enum([1,8], default_value=1, sync=True)
+    
+    def open(self):
+        # workaround ipywidgets bug causing failure to send initial state if it contains binary keys
+        _save_data = None
+        if self.data:
+            _save_data = self.data
+            self.data = b''
+        super(BinaryView, self).open()
+        if _save_data:
+            self.data = _save_data
 
 class BitWidget(BinaryView):
     '''

--- a/bitjet/bitjet.py
+++ b/bitjet/bitjet.py
@@ -1,7 +1,7 @@
 import mmap
 
-from IPython.html.widgets import DOMWidget
-from IPython.utils.traitlets import Int, Unicode, List, Instance, Bytes, Enum
+from ipywidgets import DOMWidget
+from traitlets import Int, Unicode, List, Instance, Bytes, Enum
 
 import base64
 
@@ -28,11 +28,11 @@ class BinaryView(DOMWidget):
 
     if ndarray:
         data = (
-                Bytes(sync=True, to_json=b64encode_json) |
-                Instance(ndarray, sync=True, to_json=b64encode_json)
+                Bytes(sync=True) |
+                Instance(ndarray, sync=True)
         )
     else:
-        data = Bytes(sync=True, to_json=b64encode_json)
+        data = Bytes(sync=True)
 
     blockwidth = Int(4, sync=True)
     blockheight = Int(4, sync=True)

--- a/bitjet/bitjet.py
+++ b/bitjet/bitjet.py
@@ -18,9 +18,6 @@ class BinaryView(DOMWidget):
     blockwidth = Int(4, sync=True)
     blockheight = Int(4, sync=True)
 
-    height = Int(200, sync=True)
-    width = Int(800, sync=True)
-
     bits_per_block = Enum([1,8], default_value=1, sync=True)
 
 class BitWidget(BinaryView):

--- a/bitjet/bitjet.py
+++ b/bitjet/bitjet.py
@@ -5,19 +5,6 @@ from traitlets import Int, Unicode, List, Instance, Bytes, Enum
 
 import base64
 
-try:
-    from numpy import ndarray
-except:
-    # TODO: wat
-    ndarray = None
-
-
-def b64encode_json(a):
-    '''
-    Returns a dict containing the base64 encoded a
-    '''
-    return {'b64data': base64.b64encode(a)}
-
 class BinaryView(DOMWidget):
     _view_module = Unicode('nbextensions/bitjet/bitjet', sync=True)
     _view_name = Unicode('BinaryView', sync=True)
@@ -26,13 +13,7 @@ class BinaryView(DOMWidget):
 
     datawidth = Int(2, sync=True)
 
-    if ndarray:
-        data = (
-                Bytes(sync=True) |
-                Instance(ndarray, sync=True)
-        )
-    else:
-        data = Bytes(sync=True)
+    data = Bytes(sync=True)
 
     blockwidth = Int(4, sync=True)
     blockheight = Int(4, sync=True)

--- a/bitvis.ipynb
+++ b/bitvis.ipynb
@@ -152,21 +152,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.0"
   }
  },
  "nbformat": 4,

--- a/bitvis.ipynb
+++ b/bitvis.ipynb
@@ -79,10 +79,12 @@
    "outputs": [],
    "source": [
     "# Find the hidden logo\n",
-    "for ii in range(24,64):\n",
+    "i.min=28\n",
+    "i.max=84\n",
+    "for ii in range(28,84):\n",
     "    time.sleep(0.1)\n",
     "    i.value = ii\n",
-    "    if ii == 48:\n",
+    "    if ii == 56:\n",
     "        time.sleep(1)"
    ]
   },
@@ -132,9 +134,9 @@
    },
    "outputs": [],
    "source": [
-    "bw2.blockheight = bw2.blockwidth = 3\n",
+    "bw2.blockheight = bw2.blockwidth = 2\n",
     "bw2.width = bw2.height = 512\n",
-    "bw2.data = open(\"/usr/bin/base64\", \"rb\").read(2**16)"
+    "bw2.data = open(\"/usr/bin/openssl\", \"rb\").read(2**7)"
    ]
   },
   {
@@ -152,21 +154,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.0"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/bitvis.ipynb
+++ b/bitvis.ipynb
@@ -13,21 +13,13 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      ":0: FutureWarning: IPython widgets are experimental and may change in the future.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import os, string\n",
+    "import os, string, time\n",
     "import bitjet\n",
     "from IPython.display import display\n",
-    "from IPython.html.widgets import IntSlider\n",
-    "from IPython.utils.traitlets import link"
+    "from ipywidgets import IntSlider\n",
+    "from traitlets import link"
    ]
   },
   {
@@ -79,6 +71,22 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Find the hidden logo\n",
+    "for ii in range(24,64):\n",
+    "    time.sleep(0.1)\n",
+    "    i.value = ii\n",
+    "    if ii == 48:\n",
+    "        time.sleep(1)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -87,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -105,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -118,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -131,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {
     "collapsed": true
    },
@@ -140,47 +148,25 @@
     "display(i)\n",
     "display(bw2)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [
-    "## Compatible with numpy!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "bitjet.BitWidget(data=np.array([range(32)], dtype=np.uint8),\n",
-    "                 datawidth=8, blockheight=8, blockwidth=8, width=64)"
-   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license='New BSD License',
     url='https://github.com/rgbkrk/bitjet',
     keywords='data visualization interactive interaction python ipython widgets widget',
-    install_requires=['ipython', 'jupyter-pip'],
+    install_requires=['notebook', 'ipywidgets', 'jupyter-pip'],
     classifiers=['Development Status :: 4 - Beta',
                  'Programming Language :: Python',
                  'License :: OSI Approved :: MIT License'],

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,10 @@ from setuptools import setup
 try:
     from jupyterpip import cmdclass
 except:
-    import pip, importlib
-    pip.main(['install', 'jupyter-pip']); cmdclass = importlib.import_module('jupyterpip').cmdclass
+    import pip
+    import importlib
+    pip.main(['install', 'jupyter-pip'])
+    cmdclass = importlib.import_module('jupyterpip').cmdclass
 
 setup(
     name='bitjet',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-envlist = py27, py33, py34
+envlist = py27, py34, py35
 
 [testenv]
 deps =
-  ipython
-  pyzmq
+  notebook
   nose
-  tornado<4.0
   jinja2
   sphinx
   pygments

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py27, py34, py35
 [testenv]
 deps =
   notebook
+  ipywidgets
   nose
   jinja2
   sphinx


### PR DESCRIPTION
This upgrades bitjet to the latest version of ipywidgets and relies on the binary support (thanks @jasongrout!).

One persnickety issue though. Values >= 128 are all coming out at as 65533 (2^16 - 3), which when masked, is 253. Not sure if traitlets is somehow masking it or if this is occurring in ipywidgets somehow. Once I have more time for digging, I'll hope to report something more formal in one of the repos. For now I might just try making a test that for ipywidgets that sends a full `bytes(range(256))`.

I've also extracted this to a bare minimal js package that doesn't have any dependencies, no problem with bytes across the wire there. :confounded: 

This also drops support for numpy ndarrays, because it made the code a lot simpler to use the `Bytes` traitlet directly with the binary support added so long ago. I'm assuming this might be handled best by the scipy traitlets, @SylvainCorlay?

 /cc @jdfreder 
