### PR TITLE
Use binary messages for data

### DIFF
--- a/bitjet/bitjet.js
+++ b/bitjet/bitjet.js
@@ -33,8 +33,11 @@ define(function(require) {
           var blockwidth = this.model.get("blockwidth");
           var blockheight = this.model.get("blockheight");
           var bitsPerBlock = this.model.get("bits_per_block");
+          var datacol = 0;
+          if (data !== null) {
+            datacol = Math.ceil(data.byteLength/datawidth);
+          }
 
-          var datacol = Math.ceil(data.length/datawidth);
 
           var width = datawidth*bitsPerBlock*blockwidth;
           var height = datacol*bitsPerBlock*blockheight*8;
@@ -54,7 +57,11 @@ define(function(require) {
           // Color the background gray
           context.fillStyle = "rgb(87,87,87,0.2)";
           context.clearRect(0, 0, canvas.width, canvas.height );
-
+          
+          if (data === null) {
+            // no data
+            return;
+          }
           if (bitsPerBlock === 1) {
             paintBits(context, data, datawidth, blockwidth, blockheight);
           } else if (bitsPerBlock === 8) {
@@ -72,15 +79,10 @@ define(function(require) {
                       blockwidth, blockheight) {
 
     // Paint the canvas with our bit view
-    for(var idx=0; idx < data.length; idx++) {
-      // The decoded data is a string in JavaScript land, we'll strip uint8s off
-      var el = data.charCodeAt(idx);
+    for(var idx=0; idx < data.byteLength; idx++) {
+      // The decoded data is a DataView in JavaScript land, we'll strip uint8s off
+      var el = data.getUint8(idx);
       var charsize = 8;
-      // TODO: For some reason, values >= 128 are all coming out at 65533 (2^16 - 3)
-      //       which when masked, is 253. Not sure if traitlets is somehow masking it
-      //       or what...
-      // console.log(el); // If the actual data[idx] >= 128, el == 65533
-      // console.log(el & 0xff); // which would then make the effective value 253
 
       for (i=0; i<charsize; i++){
         //Mask off that first bit
@@ -108,9 +110,9 @@ define(function(require) {
                        blockwidth, blockheight) {
 
          // Paint the canvas with our byte view
-         for(var idx=0; idx < data.length; idx++) {
-           // The decoded data is a string in JavaScript land, we'll strip uint8s off
-           var el = data.charCodeAt(idx);
+         for(var idx=0; idx < data.byteLength; idx++) {
+           // The decoded data is a DataView in JavaScript land, we'll strip uint8s off
+           var el = data.getUint8(idx);
 
            // Where does this byte get painted?
            var x = (idx % datawidth)*blockwidth;

--- a/bitjet/bitjet.py
+++ b/bitjet/bitjet.py
@@ -5,6 +5,13 @@ from traitlets import Int, Unicode, List, Instance, Bytes, Enum
 
 import base64
 
+def bytes_to_json(buf, widget):
+    """Wrap bytes objects in memoryviews to trigger binary messages."""
+    if not buf:
+        # temporary workaround since open doesn't support binary serialization
+        return None
+    return memoryview(buf)
+
 class BinaryView(DOMWidget):
     _view_module = Unicode('nbextensions/bitjet/bitjet', sync=True)
     _view_name = Unicode('BinaryView', sync=True)
@@ -13,12 +20,22 @@ class BinaryView(DOMWidget):
 
     datawidth = Int(8, sync=True)
 
-    data = Bytes(sync=True)
+    data = Bytes(sync=True, to_json=bytes_to_json)
 
     blockwidth = Int(4, sync=True)
     blockheight = Int(4, sync=True)
 
     bits_per_block = Enum([1,8], default_value=1, sync=True)
+    
+    def open(self):
+        # workaround ipywidgets bug causing failure to send initial state if it contains binary keys
+        _save_data = None
+        if self.data:
+            _save_data = self.data
+            self.data = b''
+        super(BinaryView, self).open()
+        if _save_data:
+            self.data = _save_data
 
 class BitWidget(BinaryView):
     '''


### PR DESCRIPTION
Must specify custom serialization to memoryview (this may stop being necessary)

data will be a DataView on the javascript-side.

This includes a few workarounds for upstream bugs in ipywidgets:
- ipython/ipykernel#73
- ipython/ipywidgets#231
